### PR TITLE
Fix Concourse java/cacerts location issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,8 @@ ARG jar=target/artifactory-resource.jar
 COPY ${root}/assets/ /opt/resource/
 COPY ${jar} /artifact/artifactory-resource.jar
 
+# https://github.com/concourse/concourse/issues/2042
+RUN unlink  $JAVA_HOME/jre/lib/security/cacerts && \
+cp /etc/ssl/certs/java/cacerts $JAVA_HOME/jre/lib/security/cacerts
+
 RUN chmod +x /opt/resource/check /opt/resource/in /opt/resource/out


### PR DESCRIPTION
Fix to resolve #12 base on https://github.com/patrickcrocker/maven-resource/commit/b71caebc7d9b2086885363d799a3d2f9b6acd09e