### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -36,20 +36,20 @@ They can also be added after the original pull request but before a merge.
 * Add some Javadocs.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions], if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit message (where `XXXX` is the issue number).
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions], if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit message (where `XXXX` is the issue number).
 
 
 
 == Working with the code
-If you don't have an IDE preference we would recommend that you use https://spring.io/tools/sts[Spring Tools Suite] or http://eclipse.org[Eclipse] when working with the code.
-We use the http://eclipse.org/m2e/[M2Eclipse] eclipse plugin for maven support.
+If you don't have an IDE preference we would recommend that you use https://spring.io/tools/sts[Spring Tools Suite] or https://eclipse.org[Eclipse] when working with the code.
+We use the https://eclipse.org/m2e/[M2Eclipse] eclipse plugin for maven support.
 Other IDEs and tools should also work without issue.
 
 
 
 === Building from source
 To build the source you will need to install JDK 1.8.
-The project can be build with http://maven.apache.org/run-maven/index.html[Apache Maven] v3.5 or above (the Maven wrapper is included if you don't already have Maven installed).
+The project can be build with https://maven.apache.org/run-maven/index.html[Apache Maven] v3.5 or above (the Maven wrapper is included if you don't already have Maven installed).
 
 The project can be built from the root directory using the standard Maven command:
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = Artifactory Resource image:https://ci.spring.io/api/v1/teams/artifactory-resource/pipelines/artifactory-resource/jobs/build/badge["Build Status", link="https://ci.spring.io/teams/artifactory-resource/pipelines/artifactory-resource?groups=Build"]
 
-A http://concourse.ci/[Concourse] resource to deploy and retrieve artifacts from a https://www.jfrog.com/artifactory/[JFrog Artifactory] server.
+A https://concourse.ci/[Concourse] resource to deploy and retrieve artifacts from a https://www.jfrog.com/artifactory/[JFrog Artifactory] server.
 
 
 == Overview
@@ -43,7 +43,7 @@ resources:
 - name: artifacts
   type: artifactory-resource
   source:
-    uri: http://repo.example.com
+    uri: https://repo.example.com
     username: admin
     password: secret
     build_name: my-build

--- a/samples/params.yml
+++ b/samples/params.yml
@@ -1,4 +1,4 @@
-sample-artifactory-uri: http://artifactory:8081/artifactory
+sample-artifactory-uri: https://artifactory:8081/artifactory
 sample-artifactory-username: admin
 sample-artifactory-password: password
 sample-concourse-uri: http://localhost:8080/artifactory

--- a/src/test/java/io/spring/concourse/artifactoryresource/artifactory/HttpArtifactoryBuildRunsTests.java
+++ b/src/test/java/io/spring/concourse/artifactoryresource/artifactory/HttpArtifactoryBuildRunsTests.java
@@ -87,7 +87,7 @@ public class HttpArtifactoryBuildRunsTests {
 	@Before
 	public void setup() {
 		this.artifactoryBuildRuns = this.artifactory
-				.server("http://repo.example.com", "admin", "password")
+				.server("https://repo.example.com", "admin", "password")
 				.buildRuns("my-build");
 	}
 
@@ -98,7 +98,7 @@ public class HttpArtifactoryBuildRunsTests {
 
 	@Test
 	public void addAddsBuildInfo() throws Exception {
-		this.server.expect(requestTo("http://repo.example.com/api/build"))
+		this.server.expect(requestTo("https://repo.example.com/api/build"))
 				.andExpect(method(HttpMethod.PUT))
 				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
 				.andExpect(jsonContent(getResource("payload/build-info.json")))
@@ -112,14 +112,14 @@ public class HttpArtifactoryBuildRunsTests {
 		List<BuildModule> modules = Collections.singletonList(new BuildModule(
 				"com.example.module:my-module:1.0.0-SNAPSHOT", artifacts));
 		Date started = ArtifactoryDateFormat.parse("2014-09-30T12:00:19.893+0000");
-		this.artifactoryBuildRuns.add("5678", "http://ci.example.com", agent, started,
+		this.artifactoryBuildRuns.add("5678", "https://ci.example.com", agent, started,
 				modules);
 		this.server.verify();
 	}
 
 	@Test
 	public void getAllReturnsBuildRuns() throws Exception {
-		this.server.expect(requestTo("http://repo.example.com/api/build/my-build"))
+		this.server.expect(requestTo("https://repo.example.com/api/build/my-build"))
 				.andExpect(method(HttpMethod.GET))
 				.andRespond(withSuccess(getResource("payload/build-runs-response.json"),
 						MediaType.APPLICATION_JSON));
@@ -131,7 +131,7 @@ public class HttpArtifactoryBuildRunsTests {
 
 	@Test
 	public void getRawBuildInfoReturnsBuildInfo() throws Exception {
-		this.server.expect(requestTo("http://repo.example.com/api/build/my-build/5678"))
+		this.server.expect(requestTo("https://repo.example.com/api/build/my-build/5678"))
 				.andExpect(method(HttpMethod.GET))
 				.andRespond(withSuccess(getResource("payload/build-info.json"),
 						MediaType.APPLICATION_JSON));
@@ -141,7 +141,7 @@ public class HttpArtifactoryBuildRunsTests {
 
 	@Test
 	public void fetchAllFetchesArtifactsCorrespondingToBuildAndRepo() throws Exception {
-		String url = "http://repo.example.com/api/search/aql";
+		String url = "https://repo.example.com/api/search/aql";
 		this.server.expect(requestTo(url)).andExpect(method(HttpMethod.POST))
 				.andExpect(content().contentType(MediaType.TEXT_PLAIN))
 				.andExpect(aqlContent("my-build", "1234"))

--- a/src/test/java/io/spring/concourse/artifactoryresource/artifactory/HttpArtifactoryRepositoryTests.java
+++ b/src/test/java/io/spring/concourse/artifactoryresource/artifactory/HttpArtifactoryRepositoryTests.java
@@ -83,7 +83,7 @@ public class HttpArtifactoryRepositoryTests {
 	@Before
 	public void setup() {
 		this.artifactoryRepository = this.artifactory
-				.server("http://repo.example.com", "admin", "password")
+				.server("https://repo.example.com", "admin", "password")
 				.repository("libs-snapshot-local");
 	}
 
@@ -96,7 +96,7 @@ public class HttpArtifactoryRepositoryTests {
 	public void deployUploadsTheDeployableArtifact() throws IOException {
 		DeployableArtifact artifact = new DeployableByteArrayArtifact("/foo/bar.jar",
 				BYTES);
-		String url = "http://repo.example.com/libs-snapshot-local/foo/bar.jar";
+		String url = "https://repo.example.com/libs-snapshot-local/foo/bar.jar";
 		this.server.expect(requestTo(url)).andExpect(method(HttpMethod.PUT))
 				.andExpect(header("X-Checksum-Deploy", "true"))
 				.andExpect(header("X-Checksum-Sha1", artifact.getChecksums().getSha1()))
@@ -113,7 +113,7 @@ public class HttpArtifactoryRepositoryTests {
 		properties.put("revision", "123");
 		DeployableArtifact artifact = new DeployableByteArrayArtifact("/foo/bar.jar",
 				BYTES, properties);
-		String url = "http://repo.example.com/libs-snapshot-local/foo/bar.jar;buildNumber=1;revision=123";
+		String url = "https://repo.example.com/libs-snapshot-local/foo/bar.jar;buildNumber=1;revision=123";
 		this.server.expect(requestTo(url)).andRespond(withSuccess());
 		this.artifactoryRepository.deploy(artifact);
 		this.server.verify();
@@ -123,7 +123,7 @@ public class HttpArtifactoryRepositoryTests {
 	public void deployWhenChecksumMatchesDoesNotUpload() throws Exception {
 		DeployableArtifact artifact = new DeployableByteArrayArtifact("/foo/bar.jar",
 				BYTES);
-		String url = "http://repo.example.com/libs-snapshot-local/foo/bar.jar";
+		String url = "https://repo.example.com/libs-snapshot-local/foo/bar.jar";
 		this.server.expect(requestTo(url)).andExpect(method(HttpMethod.PUT))
 				.andExpect(header("X-Checksum-Deploy", "true"))
 				.andExpect(header("X-Checksum-Sha1", artifact.getChecksums().getSha1()))
@@ -136,7 +136,7 @@ public class HttpArtifactoryRepositoryTests {
 	public void deployWhenSmallFileDoesNotUseChecksum() throws Exception {
 		DeployableArtifact artifact = new DeployableByteArrayArtifact("/foo/bar.jar",
 				"foo".getBytes());
-		String url = "http://repo.example.com/libs-snapshot-local/foo/bar.jar";
+		String url = "https://repo.example.com/libs-snapshot-local/foo/bar.jar";
 		this.server.expect(requestTo(url)).andExpect(method(HttpMethod.PUT))
 				.andExpect(noChecksumHeader()).andRespond(withSuccess());
 		this.artifactoryRepository.deploy(artifact);
@@ -148,7 +148,7 @@ public class HttpArtifactoryRepositoryTests {
 			throws Exception {
 		DeployableArtifact artifact = new DeployableByteArrayArtifact("/foo/bar.jar",
 				BYTES);
-		String url = "http://repo.example.com/libs-snapshot-local/foo/bar.jar";
+		String url = "https://repo.example.com/libs-snapshot-local/foo/bar.jar";
 		this.server.expect(requestTo(url)).andExpect(method(HttpMethod.PUT))
 				.andExpect(noChecksumHeader()).andRespond(withSuccess());
 		this.artifactoryRepository.deploy(artifact,
@@ -163,7 +163,7 @@ public class HttpArtifactoryRepositoryTests {
 
 	@Test
 	public void downloadFetchsArtifactAndWriteToFile() throws Exception {
-		String url = "http://repo.example.com/libs-snapshot-local/foo/bar.jar";
+		String url = "https://repo.example.com/libs-snapshot-local/foo/bar.jar";
 		expectFileDownload(url);
 		File destination = this.temporaryFolder.newFolder();
 		this.artifactoryRepository.download("foo/bar.jar", destination, false);
@@ -173,7 +173,7 @@ public class HttpArtifactoryRepositoryTests {
 
 	@Test
 	public void downloadFetchsChecksumFiles() throws Exception {
-		String url = "http://repo.example.com/libs-snapshot-local/foo/bar.jar";
+		String url = "https://repo.example.com/libs-snapshot-local/foo/bar.jar";
 		expectFileDownload(url);
 		expectFileDownload(url + ".md5");
 		expectFileDownload(url + ".sha1");
@@ -188,7 +188,7 @@ public class HttpArtifactoryRepositoryTests {
 
 	@Test
 	public void downloadWhenChecksumFileDoesNotFetchChecksumFiles() throws Exception {
-		String url = "http://repo.example.com/libs-snapshot-local/foo/bar.jar.md5";
+		String url = "https://repo.example.com/libs-snapshot-local/foo/bar.jar.md5";
 		expectFileDownload(url);
 		File destination = this.temporaryFolder.newFolder();
 		this.artifactoryRepository.download("foo/bar.jar.md5", destination, true);
@@ -201,7 +201,7 @@ public class HttpArtifactoryRepositoryTests {
 
 	@Test
 	public void downloadIgnoresChecksumFileFailures() throws Exception {
-		String url = "http://repo.example.com/libs-snapshot-local/foo/bar.jar";
+		String url = "https://repo.example.com/libs-snapshot-local/foo/bar.jar";
 		expectFileDownload(url);
 		expectFile404(url + ".md5");
 		expectFile404(url + ".sha1");

--- a/src/test/java/io/spring/concourse/artifactoryresource/artifactory/HttpArtifactoryTests.java
+++ b/src/test/java/io/spring/concourse/artifactoryresource/artifactory/HttpArtifactoryTests.java
@@ -49,7 +49,7 @@ public class HttpArtifactoryTests {
 
 	@Test
 	public void serverWhenNoUsernameReturnsServer() {
-		ArtifactoryServer server = this.artifactory.server("http://example.com", null,
+		ArtifactoryServer server = this.artifactory.server("https://example.com", null,
 				null);
 		RestTemplate restTemplate = (RestTemplate) ReflectionTestUtils.getField(server,
 				"restTemplate");
@@ -60,7 +60,7 @@ public class HttpArtifactoryTests {
 
 	@Test
 	public void serverWithCredentialsReturnsServerWithCredentials() throws Exception {
-		ArtifactoryServer server = this.artifactory.server("http://example.com", "admin",
+		ArtifactoryServer server = this.artifactory.server("https://example.com", "admin",
 				"password");
 		RestTemplate restTemplate = (RestTemplate) ReflectionTestUtils.getField(server,
 				"restTemplate");

--- a/src/test/java/io/spring/concourse/artifactoryresource/artifactory/payload/BuildInfoTests.java
+++ b/src/test/java/io/spring/concourse/artifactoryresource/artifactory/payload/BuildInfoTests.java
@@ -52,7 +52,7 @@ public class BuildInfoTests {
 	private static final Date STARTED = ArtifactoryDateFormat
 			.parse("2014-09-30T12:00:19.893+0000");
 
-	private static final String BUILD_URI = "http://ci.example.com";
+	private static final String BUILD_URI = "https://ci.example.com";
 
 	private static final BuildArtifact ARTIFACT = new BuildArtifact("jar",
 			"a9993e364706816aba3e25717850c26c9cd0d89d",

--- a/src/test/java/io/spring/concourse/artifactoryresource/command/CheckHandlerTests.java
+++ b/src/test/java/io/spring/concourse/artifactoryresource/command/CheckHandlerTests.java
@@ -64,7 +64,7 @@ public class CheckHandlerTests {
 	public void setup() {
 		MockitoAnnotations.initMocks(this);
 		List<BuildRun> runs = createBuildRuns();
-		given(this.artifactory.server("http://ci.example.com", "admin", "password"))
+		given(this.artifactory.server("https://ci.example.com", "admin", "password"))
 				.willReturn(this.artifactoryServer);
 		given(this.artifactoryServer.buildRuns("my-build"))
 				.willReturn(this.artifactoryBuildRuns);
@@ -89,7 +89,7 @@ public class CheckHandlerTests {
 	@Test
 	public void handleWhenVersionIsMissingRespondsWithLatest() throws Exception {
 		CheckRequest request = new CheckRequest(
-				new Source("http://ci.example.com", "admin", "password", "my-build"),
+				new Source("https://ci.example.com", "admin", "password", "my-build"),
 				null);
 		CheckResponse response = this.handler.handle(request);
 		Stream<String> buildsNumbers = response.getVersions().stream()
@@ -100,7 +100,7 @@ public class CheckHandlerTests {
 	@Test
 	public void handleWhenVersionIsPresentRespondsWithListOfVersions() throws Exception {
 		CheckRequest request = new CheckRequest(
-				new Source("http://ci.example.com", "admin", "password", "my-build"),
+				new Source("https://ci.example.com", "admin", "password", "my-build"),
 				new Version("2"));
 		CheckResponse response = this.handler.handle(request);
 		Stream<String> buildsNumbers = response.getVersions().stream()
@@ -112,7 +112,7 @@ public class CheckHandlerTests {
 	public void handleWhenVersionIsPresentAndLatestRespondsWithListOfVersions()
 			throws Exception {
 		CheckRequest request = new CheckRequest(
-				new Source("http://ci.example.com", "admin", "password", "my-build"),
+				new Source("https://ci.example.com", "admin", "password", "my-build"),
 				new Version("4"));
 		CheckResponse response = this.handler.handle(request);
 		Stream<String> buildsNumbers = response.getVersions().stream()
@@ -123,7 +123,7 @@ public class CheckHandlerTests {
 	@Test
 	public void handleWhenNoVersionsFoundRespondsWithLatest() throws Exception {
 		CheckRequest request = new CheckRequest(
-				new Source("http://ci.example.com", "admin", "password", "my-build"),
+				new Source("https://ci.example.com", "admin", "password", "my-build"),
 				new Version("5"));
 		CheckResponse response = this.handler.handle(request);
 		Stream<String> buildsNumbers = response.getVersions().stream()

--- a/src/test/java/io/spring/concourse/artifactoryresource/command/InHandlerTests.java
+++ b/src/test/java/io/spring/concourse/artifactoryresource/command/InHandlerTests.java
@@ -80,7 +80,7 @@ public class InHandlerTests {
 	public void setup() {
 		MockitoAnnotations.initMocks(this);
 		this.deployedArtifacts = createDeployedArtifacts();
-		given(this.artifactory.server("http://ci.example.com", "admin", "password"))
+		given(this.artifactory.server("https://ci.example.com", "admin", "password"))
 				.willReturn(this.artifactoryServer);
 		given(this.artifactoryServer.buildRuns("my-build"))
 				.willReturn(this.artifactoryBuildRuns);
@@ -183,7 +183,7 @@ public class InHandlerTests {
 	private InRequest createRequest(boolean generateMavenMetadata, boolean saveBuildInfo,
 			boolean downloadArtifacts, boolean downloadChecksums) {
 		InRequest request = new InRequest(
-				new Source("http://ci.example.com", "admin", "password", "my-build"),
+				new Source("https://ci.example.com", "admin", "password", "my-build"),
 				new Version("1234"), new Params(false, generateMavenMetadata,
 						saveBuildInfo, downloadArtifacts, downloadChecksums));
 		return request;

--- a/src/test/java/io/spring/concourse/artifactoryresource/command/OutHandlerTests.java
+++ b/src/test/java/io/spring/concourse/artifactoryresource/command/OutHandlerTests.java
@@ -105,7 +105,7 @@ public class OutHandlerTests {
 	@Before
 	public void setup() {
 		MockitoAnnotations.initMocks(this);
-		given(this.artifactory.server("http://ci.example.com", "admin", "password"))
+		given(this.artifactory.server("https://ci.example.com", "admin", "password"))
 				.willReturn(this.artifactoryServer);
 		given(this.artifactoryServer.repository("libs-snapshot-local"))
 				.willReturn(this.artifactoryRepository);
@@ -185,7 +185,7 @@ public class OutHandlerTests {
 		configureMockScanner(directory);
 		this.handler.handle(request, directory);
 		verify(this.artifactoryBuildRuns).add(eq("1234"),
-				eq("http://ci.example.com/1234"), this.modulesCaptor.capture());
+				eq("https://ci.example.com/1234"), this.modulesCaptor.capture());
 		List<BuildModule> buildModules = this.modulesCaptor.getValue();
 		assertThat(buildModules).hasSize(1);
 		BuildModule buildModule = buildModules.get(0);
@@ -218,7 +218,7 @@ public class OutHandlerTests {
 		configureMockScanner(directory, checksumFiles);
 		this.handler.handle(request, directory);
 		verify(this.artifactoryBuildRuns).add(eq("1234"),
-				eq("http://ci.example.com/1234"), this.modulesCaptor.capture());
+				eq("https://ci.example.com/1234"), this.modulesCaptor.capture());
 		List<BuildModule> buildModules = this.modulesCaptor.getValue();
 		assertThat(buildModules).hasSize(1);
 		BuildModule buildModule = buildModules.get(0);
@@ -268,7 +268,7 @@ public class OutHandlerTests {
 		configureMockScanner(directory, metadataFiles);
 		this.handler.handle(request, directory);
 		verify(this.artifactoryBuildRuns).add(eq("1234"),
-				eq("http://ci.example.com/1234"), this.modulesCaptor.capture());
+				eq("https://ci.example.com/1234"), this.modulesCaptor.capture());
 		List<BuildModule> buildModules = this.modulesCaptor.getValue();
 		return buildModules;
 	}
@@ -315,9 +315,9 @@ public class OutHandlerTests {
 			List<String> exclude, boolean stripSnapshotTimestamps,
 			boolean disableChecksumUploads, List<ArtifactSet> artifactSet) {
 		return new OutRequest(
-				new Source("http://ci.example.com", "admin", "password", "my-build"),
+				new Source("https://ci.example.com", "admin", "password", "my-build"),
 				new Params(false, "libs-snapshot-local", buildNumber, "folder", include,
-						exclude, "mock", "http://ci.example.com/1234",
+						exclude, "mock", "https://ci.example.com/1234",
 						stripSnapshotTimestamps, disableChecksumUploads, artifactSet));
 	}
 

--- a/src/test/java/io/spring/concourse/artifactoryresource/command/payload/CheckRequestTests.java
+++ b/src/test/java/io/spring/concourse/artifactoryresource/command/payload/CheckRequestTests.java
@@ -49,7 +49,7 @@ public class CheckRequestTests {
 	@Test
 	public void readWhenMissingVersionDeserializesJson() throws Exception {
 		CheckRequest request = this.json.readObject("check-request.json");
-		assertThat(request.getSource().getUri()).isEqualTo("http://repo.example.com");
+		assertThat(request.getSource().getUri()).isEqualTo("https://repo.example.com");
 		assertThat(request.getSource().getUsername()).isEqualTo("admin");
 		assertThat(request.getSource().getPassword()).isEqualTo("password");
 		assertThat(request.getVersion()).isNull();
@@ -58,7 +58,7 @@ public class CheckRequestTests {
 	@Test
 	public void readWhenHasVersionDeserializesJson() throws Exception {
 		CheckRequest request = this.json.readObject("check-request-with-version.json");
-		assertThat(request.getSource().getUri()).isEqualTo("http://repo.example.com");
+		assertThat(request.getSource().getUri()).isEqualTo("https://repo.example.com");
 		assertThat(request.getSource().getUsername()).isEqualTo("admin");
 		assertThat(request.getSource().getPassword()).isEqualTo("password");
 		assertThat(request.getVersion().getBuildNumber()).isEqualTo("1234");

--- a/src/test/java/io/spring/concourse/artifactoryresource/command/payload/InRequestTests.java
+++ b/src/test/java/io/spring/concourse/artifactoryresource/command/payload/InRequestTests.java
@@ -73,7 +73,7 @@ public class InRequestTests {
 	@Test
 	public void readDeserializesJson() throws Exception {
 		InRequest request = this.json.readObject("in-request.json");
-		assertThat(request.getSource().getUri()).isEqualTo("http://repo.example.com");
+		assertThat(request.getSource().getUri()).isEqualTo("https://repo.example.com");
 		assertThat(request.getSource().getUsername()).isEqualTo("admin");
 		assertThat(request.getSource().getPassword()).isEqualTo("password");
 		assertThat(request.getVersion().getBuildNumber()).isEqualTo("5678");

--- a/src/test/java/io/spring/concourse/artifactoryresource/command/payload/OutRequestTests.java
+++ b/src/test/java/io/spring/concourse/artifactoryresource/command/payload/OutRequestTests.java
@@ -81,7 +81,7 @@ public class OutRequestTests {
 	@Test
 	public void readDeserializesJson() throws Exception {
 		OutRequest request = this.json.readObject("out-request.json");
-		assertThat(request.getSource().getUri()).isEqualTo("http://repo.example.com");
+		assertThat(request.getSource().getUri()).isEqualTo("https://repo.example.com");
 		assertThat(request.getSource().getUsername()).isEqualTo("admin");
 		assertThat(request.getSource().getPassword()).isEqualTo("password");
 		assertThat(request.getParams().getBuildNumber()).isEqualTo("1234");
@@ -90,7 +90,7 @@ public class OutRequestTests {
 		assertThat(request.getParams().getInclude()).containsExactly("**");
 		assertThat(request.getParams().getExclude()).containsExactly("foo", "bar");
 		assertThat(request.getParams().getModuleLayout()).isEqualTo("maven");
-		assertThat(request.getParams().getBuildUri()).isEqualTo("http://ci.example.com");
+		assertThat(request.getParams().getBuildUri()).isEqualTo("https://ci.example.com");
 		assertThat(request.getParams().isStripSnapshotTimestamps()).isEqualTo(false);
 		assertThat(request.getParams().isDisableChecksumUploads()).isEqualTo(true);
 		List<ArtifactSet> artifactSet = request.getParams().getArtifactSet();

--- a/src/test/java/io/spring/concourse/artifactoryresource/command/payload/SourceTests.java
+++ b/src/test/java/io/spring/concourse/artifactoryresource/command/payload/SourceTests.java
@@ -49,25 +49,25 @@ public class SourceTests {
 
 	@Test
 	public void createWhenUsernameIsEmptyDoesNotThrowException() throws Exception {
-		new Source("http://repo.example.com", "", "password", "my-build");
+		new Source("https://repo.example.com", "", "password", "my-build");
 	}
 
 	@Test
 	public void createWhenPasswordIsEmptyDoesNotThrowException() throws Exception {
-		new Source("http://repo.example.com", "username", "", "my-build");
+		new Source("https://repo.example.com", "username", "", "my-build");
 	}
 
 	@Test
 	public void createWhenBuildNameIsEmptyThrowsException() throws Exception {
 		assertThatIllegalArgumentException().isThrownBy(
-				() -> new Source("http://repo.example.com", "username", "password", ""))
+				() -> new Source("https://repo.example.com", "username", "password", ""))
 				.withMessage("Build Name must not be empty");
 	}
 
 	@Test
 	public void readDeserializesJson() throws Exception {
 		Source source = this.json.readObject("source.json");
-		assertThat(source.getUri()).isEqualTo("http://repo.example.com");
+		assertThat(source.getUri()).isEqualTo("https://repo.example.com");
 		assertThat(source.getUsername()).isEqualTo("admin");
 		assertThat(source.getPassword()).isEqualTo("password");
 		assertThat(source.getBuildName()).isEqualTo("my-build");

--- a/src/test/resources/io/spring/concourse/artifactoryresource/artifactory/payload/build-info.json
+++ b/src/test/resources/io/spring/concourse/artifactoryresource/artifactory/payload/build-info.json
@@ -6,7 +6,7 @@
 		"version": "3.0.0"
 	},
 	"started": "2014-09-30T12:00:19.893+0000",
-	"url": "http://ci.example.com",
+	"url": "https://ci.example.com",
 	"modules": [{
 		"id": "com.example.module:my-module:1.0.0-SNAPSHOT",
 		"artifacts": [{

--- a/src/test/resources/io/spring/concourse/artifactoryresource/command/payload/check-request-with-version.json
+++ b/src/test/resources/io/spring/concourse/artifactoryresource/command/payload/check-request-with-version.json
@@ -1,6 +1,6 @@
 {
 	"source": {
-		"uri": "http://repo.example.com",
+		"uri": "https://repo.example.com",
 		"username": "admin",
 		"password": "password",
 		"build_name": "my-build"

--- a/src/test/resources/io/spring/concourse/artifactoryresource/command/payload/check-request.json
+++ b/src/test/resources/io/spring/concourse/artifactoryresource/command/payload/check-request.json
@@ -1,6 +1,6 @@
 {
 	"source": {
-		"uri": "http://repo.example.com",
+		"uri": "https://repo.example.com",
 		"username": "admin",
 		"password": "password",
 		"build_name": "my-build"

--- a/src/test/resources/io/spring/concourse/artifactoryresource/command/payload/in-request-without-generate-maven-metadata.json
+++ b/src/test/resources/io/spring/concourse/artifactoryresource/command/payload/in-request-without-generate-maven-metadata.json
@@ -1,6 +1,6 @@
 {
 	"source": {
-		"uri": "http://repo.example.com",
+		"uri": "https://repo.example.com",
 		"username": "admin",
 		"password": "password",
 		"build_name": "my-build"

--- a/src/test/resources/io/spring/concourse/artifactoryresource/command/payload/in-request.json
+++ b/src/test/resources/io/spring/concourse/artifactoryresource/command/payload/in-request.json
@@ -1,6 +1,6 @@
 {
 	"source": {
-		"uri": "http://repo.example.com",
+		"uri": "https://repo.example.com",
 		"username": "admin",
 		"password": "password",
 		"build_name": "my-build"

--- a/src/test/resources/io/spring/concourse/artifactoryresource/command/payload/out-request-without-artifact-set-properties.json
+++ b/src/test/resources/io/spring/concourse/artifactoryresource/command/payload/out-request-without-artifact-set-properties.json
@@ -1,6 +1,6 @@
 {
 	"source": {
-		"uri": "http://repo.example.com",
+		"uri": "https://repo.example.com",
 		"username": "admin",
 		"password": "password",
 		"build_name": "my-build"
@@ -17,7 +17,7 @@
 		],
 		"folder": "dist",
 		"module_layout" : "maven",
-		"build_uri": "http://ci.example.com",
+		"build_uri": "https://ci.example.com",
 		"strip_snapshot_timestamps": false,
 		"disable_checksum_uploads": true,
 		"artifact_set": [ {

--- a/src/test/resources/io/spring/concourse/artifactoryresource/command/payload/out-request.json
+++ b/src/test/resources/io/spring/concourse/artifactoryresource/command/payload/out-request.json
@@ -1,6 +1,6 @@
 {
 	"source": {
-		"uri": "http://repo.example.com",
+		"uri": "https://repo.example.com",
 		"username": "admin",
 		"password": "password",
 		"build_name": "my-build"
@@ -17,7 +17,7 @@
 		],
 		"folder": "dist",
 		"module_layout" : "maven",
-		"build_uri": "http://ci.example.com",
+		"build_uri": "https://ci.example.com",
 		"strip_snapshot_timestamps": false,
 		"disable_checksum_uploads": true,
 		"artifact_set": [ {

--- a/src/test/resources/io/spring/concourse/artifactoryresource/command/payload/source.json
+++ b/src/test/resources/io/spring/concourse/artifactoryresource/command/payload/source.json
@@ -1,5 +1,5 @@
 {
-	"uri": "http://repo.example.com",
+	"uri": "https://repo.example.com",
 	"username": "admin",
 	"password": "password",
 	"build_name": "my-build"


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://concourse.ci/ (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://concourse.ci/ ([https](https://concourse.ci/) result SSLHandshakeException).
* [ ] http://artifactory:8081/artifactory (UnknownHostException) with 1 occurrences migrated to:  
  https://artifactory:8081/artifactory ([https](https://artifactory:8081/artifactory) result UnknownHostException).
* [ ] http://ci.example.com (UnknownHostException) with 15 occurrences migrated to:  
  https://ci.example.com ([https](https://ci.example.com) result UnknownHostException).
* [ ] http://ci.example.com/1234 (UnknownHostException) with 4 occurrences migrated to:  
  https://ci.example.com/1234 ([https](https://ci.example.com/1234) result UnknownHostException).
* [ ] http://repo.example.com (UnknownHostException) with 18 occurrences migrated to:  
  https://repo.example.com ([https](https://repo.example.com) result UnknownHostException).
* [ ] http://repo.example.com/api/build (UnknownHostException) with 1 occurrences migrated to:  
  https://repo.example.com/api/build ([https](https://repo.example.com/api/build) result UnknownHostException).
* [ ] http://repo.example.com/api/build/my-build (UnknownHostException) with 1 occurrences migrated to:  
  https://repo.example.com/api/build/my-build ([https](https://repo.example.com/api/build/my-build) result UnknownHostException).
* [ ] http://repo.example.com/api/build/my-build/5678 (UnknownHostException) with 1 occurrences migrated to:  
  https://repo.example.com/api/build/my-build/5678 ([https](https://repo.example.com/api/build/my-build/5678) result UnknownHostException).
* [ ] http://repo.example.com/api/search/aql (UnknownHostException) with 1 occurrences migrated to:  
  https://repo.example.com/api/search/aql ([https](https://repo.example.com/api/search/aql) result UnknownHostException).
* [ ] http://repo.example.com/libs-snapshot-local/foo/bar.jar (UnknownHostException) with 7 occurrences migrated to:  
  https://repo.example.com/libs-snapshot-local/foo/bar.jar ([https](https://repo.example.com/libs-snapshot-local/foo/bar.jar) result UnknownHostException).
* [ ] http://repo.example.com/libs-snapshot-local/foo/bar.jar.md5 (UnknownHostException) with 1 occurrences migrated to:  
  https://repo.example.com/libs-snapshot-local/foo/bar.jar.md5 ([https](https://repo.example.com/libs-snapshot-local/foo/bar.jar.md5) result UnknownHostException).
* [ ] http://repo.example.com/libs-snapshot-local/foo/bar.jar;buildNumber=1;revision=123 (UnknownHostException) with 1 occurrences migrated to:  
  https://repo.example.com/libs-snapshot-local/foo/bar.jar;buildNumber=1;revision=123 ([https](https://repo.example.com/libs-snapshot-local/foo/bar.jar;buildNumber=1;revision=123) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://example.com with 2 occurrences migrated to:  
  https://example.com ([https](https://example.com) result 200).
* [ ] http://maven.apache.org/run-maven/index.html with 1 occurrences migrated to:  
  https://maven.apache.org/run-maven/index.html ([https](https://maven.apache.org/run-maven/index.html) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 1 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://eclipse.org with 1 occurrences migrated to:  
  https://eclipse.org ([https](https://eclipse.org) result 302).
* [ ] http://eclipse.org/m2e/ with 1 occurrences migrated to:  
  https://eclipse.org/m2e/ ([https](https://eclipse.org/m2e/) result 302).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1:8080 with 4 occurrences
* http://127.0.0.1:8081/artifactory with 2 occurrences
* http://localhost with 1 occurrences
* http://localhost:8080/artifactory with 1 occurrences
* http://localhost:8081/artifactory/api/build/my-build with 2 occurrences
* http://localhost:8181 with 2 occurrences