### PR TITLE
Add BuildAgent

### DIFF
--- a/src/integration/java/io/spring/concourse/artifactoryresource/artifactory/ApplicationIT.java
+++ b/src/integration/java/io/spring/concourse/artifactoryresource/artifactory/ApplicationIT.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
+import io.spring.concourse.artifactoryresource.artifactory.payload.BuildAgent;
 import io.spring.concourse.artifactoryresource.artifactory.payload.BuildArtifact;
 import io.spring.concourse.artifactoryresource.artifactory.payload.BuildModule;
 import io.spring.concourse.artifactoryresource.artifactory.payload.BuildRun;
@@ -125,7 +126,7 @@ class ApplicationIT {
 	private void addBuildRun(ArtifactoryBuildRuns artifactoryBuildRuns, String buildNumber, Instant started) {
 		BuildArtifact artifact = new BuildArtifact("test", "my-sha", "my-md5", "bar");
 		BuildModule modules = new BuildModule("foo-test", Collections.singletonList(artifact));
-		artifactoryBuildRuns.add(BuildNumber.of(buildNumber), new ContinuousIntegrationAgent("Concourse", null),
+		artifactoryBuildRuns.add(BuildNumber.of(buildNumber), new ContinuousIntegrationAgent("Concourse", null), new BuildAgent("Concourse", ""),
 				started, "ci.example.com", null, Collections.singletonList(modules));
 	}
 

--- a/src/main/java/io/spring/concourse/artifactoryresource/artifactory/ArtifactoryBuildRuns.java
+++ b/src/main/java/io/spring/concourse/artifactoryresource/artifactory/ArtifactoryBuildRuns.java
@@ -20,6 +20,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
+import io.spring.concourse.artifactoryresource.artifactory.payload.BuildAgent;
 import io.spring.concourse.artifactoryresource.artifactory.payload.BuildModule;
 import io.spring.concourse.artifactoryresource.artifactory.payload.BuildRun;
 import io.spring.concourse.artifactoryresource.artifactory.payload.ContinuousIntegrationAgent;
@@ -45,20 +46,27 @@ public interface ArtifactoryBuildRuns {
 	 */
 	default void add(BuildNumber buildNumber, Instant started, String buildUri, Map<String, String> properties,
 			List<BuildModule> modules) {
-		add(buildNumber, null, started, buildUri, properties, modules);
+		add(buildNumber, started, buildUri, properties, modules);
+	}
+
+	default void add(BuildNumber buildNumber, Instant started, String buildUri, Map<String, String> properties,
+			List<BuildModule> modules, BuildAgent buildAgent) {
+		add(buildNumber, new ContinuousIntegrationAgent("Concourse", ""), buildAgent, started, buildUri, properties,
+				modules);
 	}
 
 	/**
 	 * Add a new build run.
 	 * @param buildNumber the build number
 	 * @param continuousIntegrationAgent the CI Agent
+	 * @param buildAgent the build agent
 	 * @param started the time the build was started
 	 * @param buildUri the build URL
 	 * @param properties any build properties
 	 * @param modules the modules for the build run
 	 */
-	void add(BuildNumber buildNumber, ContinuousIntegrationAgent continuousIntegrationAgent, Instant started,
-			String buildUri, Map<String, String> properties, List<BuildModule> modules);
+	void add(BuildNumber buildNumber, ContinuousIntegrationAgent continuousIntegrationAgent, BuildAgent buildAgent,
+			Instant started, String buildUri, Map<String, String> properties, List<BuildModule> modules);
 
 	/**
 	 * Return all previous build runs.

--- a/src/main/java/io/spring/concourse/artifactoryresource/artifactory/HttpArtifactoryBuildRuns.java
+++ b/src/main/java/io/spring/concourse/artifactoryresource/artifactory/HttpArtifactoryBuildRuns.java
@@ -25,6 +25,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
+import io.spring.concourse.artifactoryresource.artifactory.payload.BuildAgent;
 import io.spring.concourse.artifactoryresource.artifactory.payload.BuildInfo;
 import io.spring.concourse.artifactoryresource.artifactory.payload.BuildModule;
 import io.spring.concourse.artifactoryresource.artifactory.payload.BuildRun;
@@ -80,11 +81,12 @@ public final class HttpArtifactoryBuildRuns implements ArtifactoryBuildRuns {
 	}
 
 	@Override
-	public void add(BuildNumber buildNumber, ContinuousIntegrationAgent continuousIntegrationAgent, Instant started,
-			String buildUri, Map<String, String> properties, List<BuildModule> modules) {
+	public void add(BuildNumber buildNumber, ContinuousIntegrationAgent continuousIntegrationAgent,
+			BuildAgent buildAgent, Instant started, String buildUri, Map<String, String> properties,
+			List<BuildModule> modules) {
 		logger.debug("Adding {} from CI agent {}", buildNumber, continuousIntegrationAgent);
-		add(new BuildInfo(this.buildName, buildNumber.toString(), continuousIntegrationAgent, started, buildUri,
-				properties, modules));
+		add(new BuildInfo(this.buildName, buildNumber.toString(), continuousIntegrationAgent, buildAgent, started,
+				buildUri, properties, modules));
 	}
 
 	private void add(BuildInfo buildInfo) {

--- a/src/main/java/io/spring/concourse/artifactoryresource/artifactory/payload/BuildAgent.java
+++ b/src/main/java/io/spring/concourse/artifactoryresource/artifactory/payload/BuildAgent.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.concourse.artifactoryresource.artifactory.payload;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.springframework.util.Assert;
+
+/**
+ * The build agent information included in {@link BuildInfo}.
+ *
+ * @author Phillip Webb
+ * @author Madhura Bhave
+ */
+public class BuildAgent {
+
+	private final String name;
+
+	private final String version;
+
+	@JsonCreator
+	public BuildAgent(@JsonProperty("name") String name, @JsonProperty("version") String version) {
+		Assert.hasText(name, "Name must not be empty");
+		this.name = name;
+		this.version = version;
+	}
+
+	public String getName() {
+		return this.name;
+	}
+
+	public String getVersion() {
+		return this.version;
+	}
+
+	@Override
+	public String toString() {
+		return this.name + ":" + this.version;
+	}
+
+}

--- a/src/main/java/io/spring/concourse/artifactoryresource/artifactory/payload/BuildInfo.java
+++ b/src/main/java/io/spring/concourse/artifactoryresource/artifactory/payload/BuildInfo.java
@@ -48,6 +48,9 @@ public class BuildInfo {
 	@JsonProperty("agent")
 	private final ContinuousIntegrationAgent continuousIntegrationAgent;
 
+	@JsonProperty("buildAgent")
+	private final BuildAgent buildAgent;
+
 	@JsonIsoDateFormat
 	private final Instant started;
 
@@ -64,14 +67,15 @@ public class BuildInfo {
 	@JsonCreator
 	public BuildInfo(@JsonProperty("name") String buildName, @JsonProperty("number") String buildNumber,
 			@JsonProperty("agent") ContinuousIntegrationAgent continuousIntegrationAgent,
-			@JsonProperty("started") Instant started, @JsonProperty("url") String buildUri,
-			@JsonProperty("properties") Map<String, String> properties,
+			@JsonProperty("buildAgent") BuildAgent buildAgent, @JsonProperty("started") Instant started,
+			@JsonProperty("url") String buildUri, @JsonProperty("properties") Map<String, String> properties,
 			@JsonProperty("modules") List<BuildModule> modules) {
 		Assert.hasText(buildName, "BuildName must not be empty");
 		Assert.hasText(buildNumber, "BuildNumber must not be empty");
 		this.buildName = buildName;
 		this.buildNumber = buildNumber;
 		this.continuousIntegrationAgent = continuousIntegrationAgent;
+		this.buildAgent = buildAgent;
 		this.started = (started != null) ? started : Instant.now();
 		this.buildUri = buildUri;
 		this.properties = (properties != null) ? Collections.unmodifiableMap(new LinkedHashMap<>(properties))
@@ -90,6 +94,10 @@ public class BuildInfo {
 
 	public ContinuousIntegrationAgent getContinuousIntegrationAgent() {
 		return this.continuousIntegrationAgent;
+	}
+
+	public BuildAgent getBuildAgent() {
+		return this.buildAgent;
 	}
 
 	public Instant getStarted() {

--- a/src/main/java/io/spring/concourse/artifactoryresource/command/OutHandler.java
+++ b/src/main/java/io/spring/concourse/artifactoryresource/command/OutHandler.java
@@ -42,6 +42,7 @@ import io.spring.concourse.artifactoryresource.artifactory.ArtifactoryRepository
 import io.spring.concourse.artifactoryresource.artifactory.ArtifactoryServer;
 import io.spring.concourse.artifactoryresource.artifactory.BuildNumber;
 import io.spring.concourse.artifactoryresource.artifactory.DeployOption;
+import io.spring.concourse.artifactoryresource.artifactory.payload.BuildAgent;
 import io.spring.concourse.artifactoryresource.artifactory.payload.BuildModule;
 import io.spring.concourse.artifactoryresource.artifactory.payload.DeployableArtifact;
 import io.spring.concourse.artifactoryresource.artifactory.payload.DeployableFileArtifact;
@@ -305,8 +306,9 @@ public class OutHandler {
 		List<BuildModule> modules = this.moduleLayouts.getBuildModulesGenerator(params.getModuleLayout())
 				.getBuildModules(artifacts);
 		Map<String, String> properties = loadProperties(params.getBuildProperties());
+		BuildAgent buildAgent = new BuildAgent("Concourse", "");
 		artifactoryServer.buildRuns(source.getBuildName()).add(buildNumber, started, params.getBuildUri(), properties,
-				modules);
+				modules, buildAgent);
 	}
 
 	private Map<String, String> loadProperties(String propertiesFile) {

--- a/src/test/java/io/spring/concourse/artifactoryresource/artifactory/HttpArtifactoryBuildRunsTests.java
+++ b/src/test/java/io/spring/concourse/artifactoryresource/artifactory/HttpArtifactoryBuildRunsTests.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import io.spring.concourse.artifactoryresource.artifactory.payload.BuildAgent;
 import io.spring.concourse.artifactoryresource.artifactory.payload.BuildArtifact;
 import io.spring.concourse.artifactoryresource.artifactory.payload.BuildModule;
 import io.spring.concourse.artifactoryresource.artifactory.payload.BuildRun;
@@ -86,6 +87,7 @@ class HttpArtifactoryBuildRunsTests {
 				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
 				.andExpect(jsonContent(getResource("payload/build-info.json"))).andRespond(withSuccess());
 		ContinuousIntegrationAgent agent = new ContinuousIntegrationAgent("Concourse", "3.0.0");
+		BuildAgent buildAgent = new BuildAgent("Concourse", "3.0.0");
 		BuildArtifact artifact = new BuildArtifact("jar", "a9993e364706816aba3e25717850c26c9cd0d89d",
 				"900150983cd24fb0d6963f7d28e17f72", "foo.jar");
 		List<BuildArtifact> artifacts = Collections.singletonList(artifact);
@@ -93,7 +95,8 @@ class HttpArtifactoryBuildRunsTests {
 				.singletonList(new BuildModule("com.example.module:my-module:1.0.0-SNAPSHOT", artifacts));
 		Instant started = ArtifactoryDateFormat.parse("2014-09-30T12:00:19.893Z");
 		Map<String, String> properties = Collections.singletonMap("made-by", "concourse");
-		buildRuns.add(BuildNumber.of("5678"), agent, started, "https://ci.example.com", properties, modules);
+		buildRuns.add(BuildNumber.of("5678"), agent, buildAgent, started, "https://ci.example.com", properties,
+				modules);
 		this.server.verify();
 	}
 

--- a/src/test/java/io/spring/concourse/artifactoryresource/artifactory/payload/BuildInfoTests.java
+++ b/src/test/java/io/spring/concourse/artifactoryresource/artifactory/payload/BuildInfoTests.java
@@ -46,6 +46,8 @@ public class BuildInfoTests {
 
 	private static final ContinuousIntegrationAgent CI_AGENT = new ContinuousIntegrationAgent("Concourse", "3.0.0");
 
+	private static final BuildAgent BUILD_AGENT = new BuildAgent("Concourse", "3.0.0");
+
 	private static final Instant STARTED = ArtifactoryDateFormat.parse("2014-09-30T12:00:19.893123Z");
 
 	private static final String BUILD_URI = "https://ci.example.com";
@@ -63,28 +65,29 @@ public class BuildInfoTests {
 
 	@Test
 	public void createWhenBuildNameIsEmptyThrowsException() {
-		assertThatIllegalArgumentException()
-				.isThrownBy(() -> new BuildInfo("", BUILD_NUMBER, CI_AGENT, STARTED, BUILD_URI, PROPERTIES, MODULES))
+		assertThatIllegalArgumentException().isThrownBy(
+				() -> new BuildInfo("", BUILD_NUMBER, CI_AGENT, BUILD_AGENT, STARTED, BUILD_URI, PROPERTIES, MODULES))
 				.withMessage("BuildName must not be empty");
 	}
 
 	@Test
 	public void createWhenBuildNumberIsEmptyThrowsException() {
-		assertThatIllegalArgumentException()
-				.isThrownBy(() -> new BuildInfo(BUILD_NAME, "", CI_AGENT, STARTED, BUILD_URI, PROPERTIES, MODULES))
+		assertThatIllegalArgumentException().isThrownBy(
+				() -> new BuildInfo(BUILD_NAME, "", CI_AGENT, BUILD_AGENT, STARTED, BUILD_URI, PROPERTIES, MODULES))
 				.withMessage("BuildNumber must not be empty");
 	}
 
 	@Test
 	public void createWhenModulesIsNullUsesEmptyList() {
-		BuildInfo buildInfo = new BuildInfo(BUILD_NAME, BUILD_NUMBER, CI_AGENT, STARTED, BUILD_URI, PROPERTIES, null);
+		BuildInfo buildInfo = new BuildInfo(BUILD_NAME, BUILD_NUMBER, CI_AGENT, BUILD_AGENT, STARTED, BUILD_URI,
+				PROPERTIES, null);
 		assertThat(buildInfo.getModules()).isNotNull().isEmpty();
 	}
 
 	@Test
 	public void writeSerializesJson() throws Exception {
-		BuildInfo buildInfo = new BuildInfo(BUILD_NAME, BUILD_NUMBER, CI_AGENT, STARTED, BUILD_URI, PROPERTIES,
-				MODULES);
+		BuildInfo buildInfo = new BuildInfo(BUILD_NAME, BUILD_NUMBER, CI_AGENT, BUILD_AGENT, STARTED, BUILD_URI,
+				PROPERTIES, MODULES);
 		assertThat(this.json.write(buildInfo)).isEqualToJson("build-info.json");
 	}
 

--- a/src/test/java/io/spring/concourse/artifactoryresource/command/OutHandlerTests.java
+++ b/src/test/java/io/spring/concourse/artifactoryresource/command/OutHandlerTests.java
@@ -151,7 +151,7 @@ class OutHandlerTests {
 		Directory directory = createDirectory();
 		configureMockScanner(directory);
 		this.handler.handle(request, directory);
-		verify(this.artifactoryBuildRuns).add(eq(BuildNumber.of("2000")), any(), any(), any(), any());
+		verify(this.artifactoryBuildRuns).add(eq(BuildNumber.of("2000")), any(), any(), any(), any(), any());
 	}
 
 	@Test
@@ -160,7 +160,7 @@ class OutHandlerTests {
 		Directory directory = createDirectory();
 		configureMockScanner(directory);
 		this.handler.handle(request, directory);
-		verify(this.artifactoryBuildRuns).add(eq(BuildNumber.of("1234")), any(), any(), any(), any());
+		verify(this.artifactoryBuildRuns).add(eq(BuildNumber.of("1234")), any(), any(), any(), any(), any());
 		verifyNoInteractions(this.buildNumberGenerator);
 	}
 
@@ -239,7 +239,7 @@ class OutHandlerTests {
 		configureMockScanner(directory);
 		this.handler.handle(request, directory);
 		verify(this.artifactoryBuildRuns).add(eq(BuildNumber.of("1234")), any(), eq("https://ci.example.com/1234"),
-				any(), this.modulesCaptor.capture());
+				any(), this.modulesCaptor.capture(), any());
 		List<BuildModule> buildModules = this.modulesCaptor.getValue();
 		assertThat(buildModules).hasSize(1);
 		BuildModule buildModule = buildModules.get(0);
@@ -258,7 +258,7 @@ class OutHandlerTests {
 		configureMockScanner(directory);
 		this.handler.handle(request, directory);
 		verify(this.artifactoryBuildRuns).add(eq(BuildNumber.of("1234")), any(), eq("https://ci.example.com/1234"),
-				this.propertiesCaptor.capture(), any());
+				this.propertiesCaptor.capture(), any(), any());
 		assertThat(this.propertiesCaptor.getValue()).containsExactly(entry("one", "value1"), entry("two", "value2"));
 	}
 
@@ -285,7 +285,7 @@ class OutHandlerTests {
 		configureMockScanner(directory, checksumFiles);
 		this.handler.handle(request, directory);
 		verify(this.artifactoryBuildRuns).add(eq(BuildNumber.of("1234")), any(), eq("https://ci.example.com/1234"),
-				any(), this.modulesCaptor.capture());
+				any(), this.modulesCaptor.capture(), any());
 		List<BuildModule> buildModules = this.modulesCaptor.getValue();
 		assertThat(buildModules).hasSize(1);
 		BuildModule buildModule = buildModules.get(0);
@@ -325,7 +325,7 @@ class OutHandlerTests {
 		configureMockScanner(directory, metadataFiles);
 		this.handler.handle(request, directory);
 		verify(this.artifactoryBuildRuns).add(eq(BuildNumber.of("1234")), any(), eq("https://ci.example.com/1234"),
-				any(), this.modulesCaptor.capture());
+				any(), this.modulesCaptor.capture(), any());
 		List<BuildModule> buildModules = this.modulesCaptor.getValue();
 		return buildModules;
 	}

--- a/src/test/resources/io/spring/concourse/artifactoryresource/artifactory/payload/build-info.json
+++ b/src/test/resources/io/spring/concourse/artifactoryresource/artifactory/payload/build-info.json
@@ -1,22 +1,30 @@
 {
-	"name": "my-build",
-	"number": "5678",
-	"agent": {
-		"name": "Concourse",
-		"version": "3.0.0"
-	},
-	"started": "2014-09-30T12:00:19.893Z",
-	"url": "https://ci.example.com",
-	"properties": {
-		"made-by": "concourse"
-	},
-	"modules": [{
-		"id": "com.example.module:my-module:1.0.0-SNAPSHOT",
-		"artifacts": [{
-			"type": "jar",
-			"sha1": "a9993e364706816aba3e25717850c26c9cd0d89d",
-			"md5": "900150983cd24fb0d6963f7d28e17f72",
-			"name": "foo.jar"
-		}]
-	}]
+  "name": "my-build",
+  "number": "5678",
+  "buildAgent": {
+    "name": "Concourse",
+    "version": "3.0.0"
+  },
+  "agent": {
+    "name": "Concourse",
+    "version": "3.0.0"
+  },
+  "started": "2014-09-30T12:00:19.893Z",
+  "url": "https://ci.example.com",
+  "properties": {
+    "made-by": "concourse"
+  },
+  "modules": [
+    {
+      "id": "com.example.module:my-module:1.0.0-SNAPSHOT",
+      "artifacts": [
+        {
+          "type": "jar",
+          "sha1": "a9993e364706816aba3e25717850c26c9cd0d89d",
+          "md5": "900150983cd24fb0d6963f7d28e17f72",
+          "name": "foo.jar"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
We are seeing 400s from artifactory when using this resource. It looks like artifactory is expecting a buildAgent property to be set now. Example exception:

```
java.lang.IllegalStateException: Failed to execute ApplicationRunner
	at org.springframework.boot.SpringApplication.callRunner(SpringApplication.java:761)
	at org.springframework.boot.SpringApplication.callRunners(SpringApplication.java:748)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:315)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1302)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1291)
	at io.spring.((redacted)).artifactoryresource.Application.main(Application.java:40)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.springframework.boot.loader.MainMethodRunner.run(MainMethodRunner.java:49)
	at org.springframework.boot.loader.Launcher.launch(Launcher.java:95)
	at org.springframework.boot.loader.Launcher.launch(Launcher.java:58)
	at org.springframework.boot.loader.JarLauncher.main(JarLauncher.java:65)
Caused by: org.springframework.web.client.HttpClientErrorException$BadRequest: 400 : "{<EOL>  "errors" : [ {<EOL>    "status" : 400,<EOL>    "message" : "Cannot invoke \"org.jfrog.build.api.BuildAgent.toString()\" because the return value of \"org.jfrog.build.api.Build.getBuildAgent()\" is null"<EOL>  } ]<EOL>}"
	at org.springframework.web.client.HttpClientErrorException.create(HttpClientErrorException.java:103)
	at org.springframework.web.client.DefaultResponseErrorHandler.handleError(DefaultResponseErrorHandler.java:183)
	at org.springframework.web.client.DefaultResponseErrorHandler.handleError(DefaultResponseErrorHandler.java:137)
	at org.springframework.web.client.ResponseErrorHandler.handleError(ResponseErrorHandler.java:63)
	at org.springframework.web.client.RestTemplate.handleResponse(RestTemplate.java:915)
	at org.springframework.web.client.RestTemplate.doExecute(RestTemplate.java:864)
	at org.springframework.web.client.RestTemplate.exchange(RestTemplate.java:704)
	at io.spring.((redacted)).artifactoryresource.artifactory.HttpArtifactoryBuildRuns.add(HttpArtifactoryBuildRuns.java:95)
	at io.spring.((redacted)).artifactoryresource.artifactory.HttpArtifactoryBuildRuns.add(HttpArtifactoryBuildRuns.java:86)
	at io.spring.((redacted)).artifactoryresource.artifactory.ArtifactoryBuildRuns.add(ArtifactoryBuildRuns.java:48)
	at io.spring.((redacted)).artifactoryresource.command.OutHandler.addBuildRun(OutHandler.java:308)
	at io.spring.((redacted)).artifactoryresource.command.OutHandler.handle(OutHandler.java:135)
	at io.spring.((redacted)).artifactoryresource.command.OutCommand.run(OutCommand.java:58)
	at io.spring.((redacted)).artifactoryresource.command.CommandProcessor.run(CommandProcessor.java:56)
	at org.springframework.boot.SpringApplication.callRunner(SpringApplication.java:758)
	... 13 common frames omitted
```