### PR TITLE
Use configured project when saving build info

### DIFF
--- a/src/main/java/io/spring/concourse/artifactoryresource/artifactory/HttpArtifactoryBuildRuns.java
+++ b/src/main/java/io/spring/concourse/artifactoryresource/artifactory/HttpArtifactoryBuildRuns.java
@@ -122,9 +122,13 @@ public final class HttpArtifactoryBuildRuns implements ArtifactoryBuildRuns {
 	public String getRawBuildInfo(BuildNumber buildNumber) {
 		logger.debug("Getting raw build info for {}", buildNumber);
 		Assert.notNull(buildNumber, "BuildNumber must not be null");
-		UriComponents uriComponents = UriComponentsBuilder.fromUriString(this.uri)
-			.path("api/build/{buildName}/{buildNumber}")
-			.buildAndExpand(this.buildName, buildNumber);
+		UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(this.uri)
+			.path("api/build/{buildName}/{buildNumber}");
+		if (this.project != null) {
+			logger.debug("Getting from project {}", this.project);
+			builder = builder.queryParam("project", this.project);
+		}
+		UriComponents uriComponents = builder.buildAndExpand(this.buildName, buildNumber);
 		URI uri = uriComponents.encode().toUri();
 		return this.restTemplate.getForObject(uri, String.class);
 	}

--- a/src/test/java/io/spring/concourse/artifactoryresource/artifactory/HttpArtifactoryBuildRunsTests.java
+++ b/src/test/java/io/spring/concourse/artifactoryresource/artifactory/HttpArtifactoryBuildRunsTests.java
@@ -282,6 +282,16 @@ class HttpArtifactoryBuildRunsTests {
 	}
 
 	@Test
+	void getRawBuildInfoWithProjectReturnsBuildInfo() {
+		ArtifactoryBuildRuns buildRuns = buildRuns("my-project");
+		this.server.expect(requestTo("https://repo.example.com/api/build/my-build/5678?project=my-project"))
+			.andExpect(method(HttpMethod.GET))
+			.andRespond(withSuccess(getResource("payload/build-info.json"), MediaType.APPLICATION_JSON));
+		String buildInfo = buildRuns.getRawBuildInfo(BuildNumber.of("5678"));
+		assertThat(buildInfo).isNotEmpty().contains("my-build");
+	}
+
+	@Test
 	void fetchAllFetchesArtifactsCorrespondingToBuildAndRepo() {
 		ArtifactoryBuildRuns buildRuns = buildRuns();
 		String url = "https://repo.example.com/api/search/aql";


### PR DESCRIPTION
Related to #115 .

The changes in the original commit ( https://github.com/spring-io/artifactory-resource/commit/40e4d1b3016dad1cc9f65a8515effc61d97ad273 ) covers the upload (put) operation.  
The changes in this PR covers the download (get) operation. 